### PR TITLE
Reimplement with an array (ArrayDeque)

### DIFF
--- a/memory/deque-memory-usage.js
+++ b/memory/deque-memory-usage.js
@@ -1,0 +1,17 @@
+const {Deque} = require('../build');
+
+const N = 1000000000;
+const d = new Deque();
+
+for (let i = 0; i < N; i++) {
+  if (i % 2 === 0) {
+    d.unshift(1);
+  } else {
+    d.shift();
+  }
+}
+
+const used = process.memoryUsage();
+for (let key in used) {
+  console.log(`${key} ${Math.round(used[key] / 1024 / 1024 * 100) / 100} MB`);
+}

--- a/src/deque.ts
+++ b/src/deque.ts
@@ -9,8 +9,8 @@ class Node<T> {
 }
 
 export class Deque<T> {
-  head?: Node<T>;
-  tail?: Node<T>;
+  private head?: Node<T>;
+  private tail?: Node<T>;
   length = 0;
 
   push(val: T): T {

--- a/src/deque.ts
+++ b/src/deque.ts
@@ -51,4 +51,12 @@ export class Deque<T> {
     }
     return this.q[this.end];
   }
+  at(pos: number) {
+    if (this.start + 1 + pos > this.end) {
+      throw new RangeError(
+        'Cannot access the element. Position is out of range.'
+      );
+    }
+    return this.q[this.start + 1 + pos];
+  }
 }

--- a/src/deque.ts
+++ b/src/deque.ts
@@ -1,96 +1,54 @@
-class Node<T> {
-  val: T;
-  next?: Node<T>;
-  prev?: Node<T>;
-
-  constructor(val: T) {
-    this.val = val;
-  }
-}
-
 export class Deque<T> {
-  private head?: Node<T>;
-  private tail?: Node<T>;
-  length = 0;
+  private q: T[] = [];
+  private start = 0;
+  private end = 0;
 
-  push(val: T): T {
-    const next = new Node<T>(val);
-
-    this.length++;
-
-    if (!this.tail) {
-      this.head = this.tail = next;
-    } else {
-      this.tail.next = next;
-      next.prev = this.tail;
-      this.tail = this.tail.next;
-    }
-    return this.tail.val;
+  get length() {
+    return this.end - this.start;
   }
-  pop(): T {
-    if (!this.tail) {
-      throw new RangeError('Cannot pop. Your container is empty.');
+  push(val: T): T {
+    if (!this.length) {
+      this.q[this.start] = val;
     }
-
-    this.length--;
-
-    if (this.head === this.tail) {
-      const val = this.tail.val;
-      this.head = this.tail = undefined;
-      return val;
-    }
-    const val = this.tail.val;
-    const prev = this.tail.prev as Node<T>;
-    prev.next = undefined;
-    this.tail = prev;
+    this.q[++this.end] = val;
     return val;
   }
-  unshift(val: T): T {
-    const head = new Node<T>(val);
-
-    this.length++;
-
-    if (!this.head) {
-      this.head = this.tail = head;
-    } else {
-      this.head.prev = head;
-      head.next = this.head;
-      this.head = head;
+  pop(): T {
+    if (!this.length) {
+      throw new RangeError('Cannot pop. Your container is empty.');
     }
+    return this.q[this.end--];
+  }
+  unshift(val: T): T {
+    if (!this.length) {
+      this.q[this.end] = val;
+    }
+    this.q[--this.start] = val;
     return val;
   }
   shift(): T {
-    if (!this.head) {
+    if (!this.length) {
       throw new RangeError('Cannot shift. Your container is empty.');
     }
-
-    this.length--;
-
-    if (this.head === this.tail) {
-      const val = this.head.val;
-      this.head = this.tail = undefined;
-      return val;
-    }
-    const val = this.head.val;
-    const next = this.head.next as Node<T>;
-    next.prev = undefined;
-    this.head = next;
-    return val;
+    return this.q[this.start++];
   }
   front() {
-    if (!this.head) {
+    if (!this.length) {
       throw new RangeError(
         'Cannot access the element. Your container is empty.'
       );
     }
-    return this.head.val;
+    if (this.end - this.start === 1) {
+      return this.q[this.end];
+    }
+    return this.q[this.start];
   }
   back() {
-    if (!this.tail) {
+    if (!this.length) {
       throw new RangeError(
         'Cannot access the element. Your container is empty.'
       );
     }
-    return this.tail.val;
+    return this.q[this.end];
   }
 }

--- a/tests/deque.test.ts
+++ b/tests/deque.test.ts
@@ -192,4 +192,54 @@ describe('Deque', () => {
       expect(result).toStrictEqual([3, 2, 1]);
     });
   });
+  describe('at', () => {
+    it('test #0', () => {
+      const deque = new Deque<number>();
+      deque.push(1);
+      deque.push(2);
+      deque.push(3);
+      deque.unshift(4);
+      deque.unshift(5);
+
+      expect(deque.at(2)).toBe(1);
+    });
+    it('test #1', () => {
+      const deque = new Deque<number>();
+      deque.push(1);
+      deque.push(2);
+      deque.push(3);
+
+      expect(deque.at(2)).toBe(3);
+    });
+    it('test #2', () => {
+      const deque = new Deque<number>();
+      deque.push(1);
+      deque.push(2);
+      deque.push(3);
+      deque.pop();
+      deque.pop();
+
+      expect(deque.at(0)).toBe(1);
+    });
+    it('test #3', () => {
+      const deque = new Deque<number>();
+      deque.push(1);
+      deque.push(2);
+
+      expect(() => deque.at(2)).toThrowError(
+        'Cannot access the element. Position is out of range.'
+      );
+    });
+    it('test #4', () => {
+      const deque = new Deque<number>();
+      deque.push(1);
+      deque.push(2);
+      deque.pop();
+      deque.pop();
+
+      expect(() => deque.at(0)).toThrowError(
+        'Cannot access the element. Position is out of range.'
+      );
+    });
+  });
 });

--- a/tests/deque.test.ts
+++ b/tests/deque.test.ts
@@ -18,8 +18,8 @@ describe('Deque', () => {
          * You might check some state using jest's expect.
          */
         expect: (deque: Deque<number>) => {
-          expect(deque.head && deque.head.val).toEqual(1);
-          expect(deque.tail && deque.tail.val).toEqual(1);
+          expect(deque.front()).toEqual(1);
+          expect(deque.back()).toEqual(1);
         },
       },
       {
@@ -30,8 +30,8 @@ describe('Deque', () => {
         ],
         args: [1, 2, 3],
         expect: (deque: Deque<number>) => {
-          expect(deque.head && deque.head.val).toEqual(1);
-          expect(deque.tail && deque.tail.val).toEqual(3);
+          expect(deque.front()).toEqual(1);
+          expect(deque.back()).toEqual(3);
         },
       },
       {
@@ -44,8 +44,8 @@ describe('Deque', () => {
         ],
         args: [1, 2, 3, null, null],
         expect: (deque: Deque<number>) => {
-          expect(deque.head && deque.head.val).toEqual(1);
-          expect(deque.tail && deque.tail.val).toEqual(1);
+          expect(deque.front()).toEqual(1);
+          expect(deque.back()).toEqual(1);
         },
       },
       {
@@ -59,8 +59,8 @@ describe('Deque', () => {
         ],
         args: [1, 2, null, 3, null, 4],
         expect: (deque: Deque<number>) => {
-          expect(deque.head && deque.head.val).toEqual(1);
-          expect(deque.tail && deque.tail.val).toEqual(4);
+          expect(deque.front()).toEqual(1);
+          expect(deque.back()).toEqual(4);
         },
       },
     ];
@@ -97,7 +97,7 @@ describe('Deque', () => {
       deque.push(2);
       deque.unshift(3);
 
-      expect(deque.head && deque.head.val).toBe(3);
+      expect(deque.front()).toBe(3);
     });
     it('test #1', () => {
       const deque = new Deque<number>();
@@ -106,8 +106,8 @@ describe('Deque', () => {
       deque.push(2);
       deque.shift();
 
-      expect(deque.head && deque.head.val).toBe(2);
-      expect(deque.tail && deque.tail.val).toBe(2);
+      expect(deque.front()).toBe(2);
+      expect(deque.back()).toBe(2);
     });
   });
   describe('#shift', () => {


### PR DESCRIPTION
Fixes #9 

All tests pass. Benchmarks show `push & pop` is faster for native arrays but `shift & unshift` is faster for deque, especially `unshift`.

The idea is similar to "implementing deque as a circular array" but in this case, it can grow infinitely since `arr[-1]` is okay in JavaScript (arrays are basically hash maps).

### TODO

- [x] implement `[]` access
- [ ] implement [`insert`](https://en.cppreference.com/w/cpp/container/deque/insert)