### PR TITLE
Heaps bug fixes

### DIFF
--- a/src/priorityQueue.ts
+++ b/src/priorityQueue.ts
@@ -1,4 +1,10 @@
-export class PriorityQueue<T> {
+export interface IPriorityQueue<T> {
+  top(): T;
+  push(val: T): void;
+  pop(): void;
+}
+
+export class PriorityQueue<T> implements IPriorityQueue<T> {
   constructor(comparator: (a: T, b: T) => boolean) {
     this.comparator = comparator;
   }

--- a/src/priorityQueue.ts
+++ b/src/priorityQueue.ts
@@ -26,6 +26,10 @@ export class PriorityQueue<T> implements IPriorityQueue<T> {
     this.sinkDown(0);
   }
 
+  size() {
+    return this.q.length;
+  }
+
   private q: T[] = [];
   private comparator: (a: T, b: T) => boolean;
   private bubbleUp() {

--- a/src/priorityQueue.ts
+++ b/src/priorityQueue.ts
@@ -49,10 +49,13 @@ export class PriorityQueue<T> implements IPriorityQueue<T> {
     const right = 2 * max + 2;
     let curr = max;
 
-    if (left <= this.q.length && this.q[left] > this.q[curr]) {
+    if (left <= this.q.length && this.comparator(this.q[left], this.q[curr])) {
       curr = left;
     }
-    if (right <= this.q.length && this.q[right] > this.q[curr]) {
+    if (
+      right <= this.q.length &&
+      this.comparator(this.q[right], this.q[curr])
+    ) {
       curr = right;
     }
     if (curr !== max) {

--- a/src/priorityQueue.ts
+++ b/src/priorityQueue.ts
@@ -22,8 +22,12 @@ export class PriorityQueue<T> implements IPriorityQueue<T> {
     if (this.q.length === 0) {
       throw new RangeError('Cannot pop. Your container is empty.');
     }
-    this.q[0] = this.q.pop() as T;
-    this.sinkDown(0);
+    if (this.size() === 1) {
+      this.q.pop();
+    } else {
+      this.q[0] = this.q.pop() as T;
+      this.sinkDown(0);
+    }
   }
 
   size() {

--- a/tests/priorityQueue.test.ts
+++ b/tests/priorityQueue.test.ts
@@ -36,5 +36,13 @@ describe('PriorityQueue', () => {
 
       expect(heap.top()).toBe(5);
     });
+    it('test #2', () => {
+      const heap = new PriorityQueue<number>((a, b) => a - b < 0);
+
+      heap.push(-3);
+      heap.pop();
+
+      expect(heap.size()).toBe(0);
+    });
   });
 });

--- a/tests/priorityQueue.test.ts
+++ b/tests/priorityQueue.test.ts
@@ -22,4 +22,19 @@ describe('PriorityQueue', () => {
       expect(heap.top()).toBe(2);
     });
   });
+  describe('Min Heap push & pop', () => {
+    it('test #1', () => {
+      const heap = new PriorityQueue<number>((a, b) => a - b < 0);
+
+      heap.push(4);
+      heap.push(5);
+      heap.push(8);
+      heap.pop();
+      heap.push(5);
+      heap.pop();
+      heap.push(10);
+
+      expect(heap.top()).toBe(5);
+    });
+  });
 });


### PR DESCRIPTION
I caught a couple of bugs, and lack of `size` method after solving https://leetcode.com/problems/kth-largest-element-in-a-stream/ (heaps) 😃 

Here's the solution, btw:

```js
/**
 * @param {number} k
 * @param {number[]} nums
 */
var KthLargest = function(k, nums) {
    this.k = k;
    this.q = new PriorityQueue((a, b) => a - b < 0);
    nums.forEach((val) => this.add(val));
};

/** 
 * @param {number} val
 * @return {number}
 */
KthLargest.prototype.add = function(val) {
    if (this.q.size() < this.k) {
        this.q.push(val);
    } else if (val > this.q.top()) {
        this.q.pop();
        this.q.push(val);
    }
    return this.q.top();
};
```

Looks concise 👍  